### PR TITLE
fix for subdirectory installations

### DIFF
--- a/Classes/Service/CountryService.php
+++ b/Classes/Service/CountryService.php
@@ -122,7 +122,7 @@ class CountryService
             $path = ($uri ?: new Uri((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . ':// . ' . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '')))->getPath();
 
             return
-                preg_match('/^\/?[a-z]{2}' . LanguageManipulationService::BASE_DELIMITER . '([a-zA-Z0-9_-]+)/', $path, $matches)
+                preg_match('/\/?[a-z]{2}' . LanguageManipulationService::BASE_DELIMITER . '([a-zA-Z0-9_-]+)/', $path, $matches)
                 && ($countryParameter = $matches[1])
                 && ($country = self::getCountryByParameter($countryParameter)) ? $country : null;
         };

--- a/Classes/Service/LanguageManipulationService.php
+++ b/Classes/Service/LanguageManipulationService.php
@@ -45,7 +45,10 @@ class LanguageManipulationService
     public static function getBase(SiteLanguage $language, Country $country = null): UriInterface
     {
         if ($country && ($parameter = $country->getParameter())) {
-            return $language->getBase()->withPath('/' . self::cleanIsoCode($language->getTwoLetterIsoCode(), 2, true) . self::BASE_DELIMITER . self::cleanString($parameter) . '/');
+            $basePath = $language->getBase()->getPath();
+            $langIsoCode = $language->getTwoLetterIsoCode();
+            $newIsoCode = self::cleanIsoCode($language->getTwoLetterIsoCode(), 2, true) . self::BASE_DELIMITER . self::cleanString($parameter);
+            return $language->getBase()->withPath(preg_replace('/('.$langIsoCode.'(?!.*'.$langIsoCode.'))/', $newIsoCode, $basePath));
         }
 
         return self::getOriginalLanguage($language)->getBase();


### PR DESCRIPTION
In my development envirnoment, typo3 installations don't have their own domain but run in subdirectories. F.E. http://localhost/projectname/public/

This fix allows for such setups. Not extensively tested, but i don't see it causing any obvious problems

