### PR TITLE
DBAL: Ensure compatibility for TYPO3 10 LTS

### DIFF
--- a/Classes/Menu/AbstractMenu.php
+++ b/Classes/Menu/AbstractMenu.php
@@ -82,7 +82,7 @@ abstract class AbstractMenu implements MenuInterface
             ->from(self::TABLE_NAME)
             ->where($this->queryBuilder->expr()->andX(...$constraints))
             ->execute()
-            ->fetchOne();
+            ->fetchColumn();
     }
 
     protected function isAvailableCountry(Country $country = null): bool
@@ -97,7 +97,7 @@ abstract class AbstractMenu implements MenuInterface
             ->from(self::TABLE_NAME)
             ->where($this->queryBuilder->expr()->andX(...$constraints))
             ->execute()
-            ->fetchOne();
+            ->fetchColumn();
     }
 
     protected function createLink(SiteLanguage $language, Country $country = null): ?string

--- a/Classes/Service/CountryService.php
+++ b/Classes/Service/CountryService.php
@@ -47,7 +47,7 @@ class CountryService
 
             return array_map(static function ($row) {
                 return Country::makeInstance($row);
-            }, $queryBuilder->select('*')->from('tx_z7countries_country')->execute()->fetchAllAssociative());
+            }, $queryBuilder->select('*')->from('tx_z7countries_country')->execute()->fetchAll(FetchMode::ASSOCIATIVE));
         };
 
         return self::cacheObject($function, 'allCountries');


### PR DESCRIPTION
TYPO3 10.4.x (10 LTS) comes with an older DBAL if installed directly from source instead of a composer-based installation. Since the extension claims to support 10.4.x as well some function-calls need to be adjusted to still workaround missing methods.

Resolves: #9 